### PR TITLE
Correct how the temp bed files are created

### DIFF
--- a/lib/MyShortRead/MyShortRead.pm
+++ b/lib/MyShortRead/MyShortRead.pm
@@ -16,6 +16,7 @@ package MyShortRead::MyShortRead;
 
 use POSIX;
 use Time::HiRes qw(time);
+use File::Temp qw(tempfile);
 
 require Exporter;
 our @ISA = qw(Exporter);
@@ -264,12 +265,7 @@ sub sep_chrom_bed{
 	my %hsh_chrname;	# hash of chromosome file names.
 	# Create chromosome files for writing.
 	foreach my $chrom(@chrname){
-		my $chrfile = $timehead . $chrom . ".bed";
-		while(-e $chrfile){	# prevent existing files from being overridden.
-			$chrfile = ($timehead + rand) . $chrom . ".bed";
-		}
-		my $fh;
-		open $fh, ">", $chrfile or die "Cannot create bed file:$!\n";
+		my ($fh, $chrfile) = tempfile( "diffreps$chrom.bed.XXXXX", TMPDIR => 1 );
 		$hsh_chrfile{$chrom} = $fh;
 		$hsh_chrname{$chrom} = $chrfile;
 	}

--- a/lib/MyShortRead/MyShortRead.pm
+++ b/lib/MyShortRead/MyShortRead.pm
@@ -28,7 +28,7 @@ our @ISA = qw(Exporter);
 # If you do not need this, moving things directly into @EXPORT or @EXPORT_OK
 # will save memory.
 our %EXPORT_TAGS = ( 'all' => [ qw(
-	
+
 ) ] );
 
 our @EXPORT_OK = ( @{ $EXPORT_TAGS{'all'} } );
@@ -40,17 +40,17 @@ our $VERSION = '1.00';
 
 # Preloaded methods go here.
 
-# Comparing two genomic intervals according to start or end position. 
+# Comparing two genomic intervals according to start or end position.
 sub compare2{
   my($a,$b) = @_;
-  my $cmpby = 'start'; 
+  my $cmpby = 'start';
   if(@_ > 2) {$cmpby = $_[2];}
 
   $a->{chrom} =~ /^(chr)?(\w+)$/;
   my $chr1 = $2;
   $b->{chrom} =~ /^(chr)?(\w+)$/;
   my $chr2 = $2;
-  
+
   # $chr1 = 100 if uc $chr1 eq 'X';
   # $chr1 = 101 if uc $chr1 eq 'Y';
   # $chr1 = 102 if uc $chr1 eq 'M';
@@ -85,7 +85,7 @@ sub order_chr{
   # # Get rid of 'chr' if exists.
   # $chr1 =~ /^(chr)?(\w+)$/; $chr1 = $2;
   # $chr2 =~ /^(chr)?(\w+)$/; $chr2 = $2;
-  # # Convert letters to large numbers.  
+  # # Convert letters to large numbers.
   # $chr1 = 100 if uc $chr1 eq 'X';
   # $chr1 = 101 if uc $chr1 eq 'Y';
   # $chr1 = 102 if uc $chr1 eq 'M';
@@ -122,7 +122,7 @@ sub find_lowest_list{
 sub overlap2{
   my($refintrv1, $refintrv2) = @_;
   if($refintrv1->{chrom} eq $refintrv2->{chrom}){
-    if($refintrv1->{'start'} <= $refintrv2->{'end'} and 
+    if($refintrv1->{'start'} <= $refintrv2->{'end'} and
        $refintrv1->{'end'} >= $refintrv2->{'start'}){
       return 1;
     }
@@ -336,7 +336,7 @@ MyShortRead::MyShortRead - My Perl library to deal with nextgen short read data.
 
 =head1 DESCRIPTION
 
-  This module contains a few functions that I created to perform some operations on 
+  This module contains a few functions that I created to perform some operations on
   short read data from next-generation sequencing machines. They include separate a
   BED file according to chromosomes; bin genome and count the number of reads; compare
   two genomic intervals and determine which one comes first(on the left side).

--- a/lib/MyShortRead/MyShortRead.pm
+++ b/lib/MyShortRead/MyShortRead.pm
@@ -265,7 +265,7 @@ sub sep_chrom_bed{
 	my %hsh_chrname;	# hash of chromosome file names.
 	# Create chromosome files for writing.
 	foreach my $chrom(@chrname){
-		my ($fh, $chrfile) = tempfile( "diffreps$chrom.bed.XXXXX", TMPDIR => 1 );
+		my ($fh, $chrfile) = tempfile( "diffreps-$chrom-XXXXXXXXXX", SUFFIX => ".bed", TMPDIR => 1 );
 		$hsh_chrfile{$chrom} = $fh;
 		$hsh_chrname{$chrom} = $chrfile;
 	}


### PR DESCRIPTION
This is slightly related to https://github.com/shenlab-sinai/diffreps/issues/4 and also to another issue that has been observed, the latter where some of the resulting bed files could end up with "corrupt" content, but never in a consistent way.

There appears to be a problem with how [`sep_chrom_bed`](https://github.com/shenlab-sinai/diffreps/blob/5f90fcebc2f7f0f1ca4a67f1370a6f8fb4c5938d/lib/MyShortRead/MyShortRead.pm#L266-L275) creates the bed files. The naming seems designed to try and avoid clashes but, unfortunately, stands a good chance of ensuring clashes in some situations.

The main problem is that, rather than using conventional methods of generating temp files, [a file name is generated from `time`](https://github.com/shenlab-sinai/diffreps/blob/5f90fcebc2f7f0f1ca4a67f1370a6f8fb4c5938d/lib/MyShortRead/MyShortRead.pm#L267), is [checked for](https://github.com/shenlab-sinai/diffreps/blob/5f90fcebc2f7f0f1ca4a67f1370a6f8fb4c5938d/lib/MyShortRead/MyShortRead.pm#L268), and if it looks like it already exists [a new name is generated with `rand`](https://github.com/shenlab-sinai/diffreps/blob/5f90fcebc2f7f0f1ca4a67f1370a6f8fb4c5938d/lib/MyShortRead/MyShortRead.pm#L269) (the use of + rather than . in that being the cause of https://github.com/shenlab-sinai/diffreps/issues/4). Unfortunately, if multiple processes are being used, this can result in the same sequence of possible file names being generated.

Note that `Parallel::ForkManager` is used to handle parallel processes, and that [it has this warning about `rand`](https://metacpan.org/pod/Parallel::ForkManager#USING-RAND()-IN-FORKED-PROCESSES).

My thinking here is that it might be possible for more than one process to arrive on the same file name at the same time, and then both write to the same file and cause issues and apparent corruption.

This pull request contains changes that switch to using perl's own `tempfile` function to generate the file names.